### PR TITLE
Add support for dragonflybsd and netbsd.

### DIFF
--- a/unix.go
+++ b/unix.go
@@ -1,4 +1,4 @@
-// +build linux darwin freebsd openbsd solaris
+// +build linux darwin dragonfly freebsd netbsd openbsd solaris
 
 package gsyslog
 

--- a/unsupported.go
+++ b/unsupported.go
@@ -1,4 +1,4 @@
-// +build windows plan9 netbsd
+// +build windows plan9
 
 package gsyslog
 


### PR DESCRIPTION
I switched the build flag to a blacklist of the unsupported platforms instead of a whitelist.  You could also just add `dragonfly` to the existing list if you prefer.