### PR TITLE
Add nacl build tag to unsupported.go

### DIFF
--- a/unsupported.go
+++ b/unsupported.go
@@ -1,4 +1,4 @@
-// +build windows plan9
+// +build windows plan9 nacl
 
 package gsyslog
 


### PR DESCRIPTION
This is the last thing keeping us from building Caddy for nacl (not a big deal, but simple enough fix).