### PR TITLE
ci: Add copywrite workflow and modernize build and test. 

### DIFF
--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -1,0 +1,6 @@
+schema_version = 1
+
+project {
+  license        = "MIT"
+  copyright_year = 2016
+}

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,5 +1,5 @@
-# Copyright IBM Corp. 2014, 2025
-# SPDX-License-Identifier: MPL-2.0
+# Copyright IBM Corp. 2016, 2026
+# SPDX-License-Identifier: MIT
 
 version: 2
 
@@ -10,6 +10,10 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "[chore] : "
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: "gomod"
     directory: "/"
@@ -17,3 +21,7 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "[chore] : "
+    groups:
+      go:
+        patterns:
+          - "*"

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,30 +1,34 @@
 name: Build and Test Workflow
 
 on:
-    pull_request:
-        branches: [ "master" ]
+  pull_request:
+    branches: ["master"]
+  push:
+    branches: ["master"]
 
 jobs:
-    build:
-        runs-on: ubuntu-latest
-
-        steps:
-            - name: Checkout Code
-              uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
-            - name: Setup Go
-              uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
-              with:
-                go-version: '1.23'
-            - name: Run golangci-lint
-              uses: golangci/golangci-lint-action@08e2f20817b15149a52b5b3ebe7de50aff2ba8c5
-            - name: Run test and generate reports
-              run: go test -v ./... -coverprofile=coverage.out
-            - name: Upload Coverage Test
-              uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
-              with:
-                name: Coverage-report
-                path: coverage.out
-            - name: Display the report
-              run: go tool cover -func=coverage.out
-            - name: Build Go
-              run: go build ./...
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: ["oldstable", "stable"]
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      - name: Setup Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@82606bf257cbaff209d206a39f5134f0cfbfd2ee # v9.2.1
+      - name: Run test and generate reports
+        run: go test -v -race ./... -coverprofile=coverage.out
+      - name: Upload Coverage Test
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: Coverage-report
+          path: coverage.out
+      - name: Display the report
+        run: go tool cover -func=coverage.out
+      - name: Build Go
+        run: go build ./...

--- a/.github/workflows/copywrite.yaml
+++ b/.github/workflows/copywrite.yaml
@@ -1,0 +1,24 @@
+name: Check Copywrite Headers
+
+on:
+  pull_request:
+  push:
+    branches:
+      - "main"
+
+jobs:
+  copywrite:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - uses: hashicorp/setup-copywrite@32638da2d4e81d56a0764aa1547882fc4d209636 # v1.1.3
+        name: Setup Copywrite
+        with:
+          version: v0.25.3
+          archive-checksum: e43f4b72fff3f219c5a5f883438d63edd5b68f5bea90a5d18abb3001c8c3aedc
+      - name: Check Header Compliance
+        run: make copywriteheaders
+permissions:
+  contents: read

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,4 +7,3 @@ linters:
     - errcheck
     - modernize
     - staticcheck
-output_format: colored-line-number

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,9 +1,10 @@
-# Copyright IBM Corp. 2014, 2025
+# Copyright IBM Corp. 2016, 2026
 # SPDX-License-Identifier: MIT
 
+version: "2"
 linters:
   enable:
     - errcheck
-    - gosimple
+    - modernize
     - staticcheck
-output_format: colored-line-number 
+output_format: colored-line-number

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright IBM Corp. 2014, 2025
+Copyright IBM Corp. 2016, 2026
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+default: copywriteheaders lint test
+
+.PHONY: copywriteheaders
+copywriteheaders:
+	@echo "==> Running copywrite headers plan..."
+	@copywrite headers --plan
+	@echo "==> Done"
+
+.PHONY: deps
+deps:
+	@go install github.com/hashicorp/copywrite@b3e6599f43beff698f471c6f46888045453fa030 # v0.25.3
+	@go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@c0d3ddc9cf3faa61a4e378e879ece580256d76e5 # v2.12.2
+
+.PHONY: lint
+lint:
+	@echo "==> Running linters..."
+	@golangci-lint run
+	@echo "==> Done"
+
+.PHONY: test
+test:
+	@echo "==> Running tests..."
+	@go test -v -race ./...
+	@echo "==> Done"

--- a/builtin.go
+++ b/builtin.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MIT
 
 // This file is taken from the log/syslog in the standard lib.
@@ -6,7 +6,6 @@
 // to block indefinitely. This is fixed by adding a write deadline.
 //
 //go:build !windows && !nacl && !plan9
-// +build !windows,!nacl,!plan9
 
 package gsyslog
 
@@ -99,7 +98,7 @@ func dialBuiltin(network, raddr string, priority syslog.Priority, tag string) (*
 func (w *builtinWriter) connect() (err error) {
 	if w.conn != nil {
 		// ignore err from close, it makes sense to continue anyway
-		w.conn.close()
+		_ = w.conn.close()
 		w.conn = nil
 	}
 
@@ -218,5 +217,5 @@ func unixSyslog() (conn serverConn, err error) {
 			}
 		}
 	}
-	return nil, errors.New("Unix syslog delivery error")
+	return nil, errors.New("Unix syslog delivery error") //nolint: staticcheck
 }

--- a/syslog.go
+++ b/syslog.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MIT
 
 package gsyslog

--- a/unix.go
+++ b/unix.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MIT
 
 // +build linux darwin dragonfly freebsd netbsd openbsd solaris
@@ -70,7 +70,7 @@ func (b *builtinLogger) WriteLevel(p Priority, buf []byte) error {
 	case LOG_DEBUG:
 		_, err = b.writeAndRetry(syslog.LOG_DEBUG, m)
 	default:
-		err = fmt.Errorf("Unknown priority: %v", p)
+		err = fmt.Errorf("Unknown priority: %v", p) //nolint: staticcheck
 	}
 	return err
 }

--- a/unsupported.go
+++ b/unsupported.go
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2014, 2025
+// Copyright IBM Corp. 2016, 2026
 // SPDX-License-Identifier: MIT
 
 // +build windows plan9 nacl


### PR DESCRIPTION
This changes adds a copywrite workflow to meet compliance
requirements along with a makefile target.

The code lint has been moved over to golangci-lint. A makefile
target has also been added for easier local running.

The test workflow now also runs tests with the race flag, to
ensure these are surfaced and uses stable and oldstable Go rather
than an EOL version.

Jira: https://hashicorp.atlassian.net/browse/NMD-1554